### PR TITLE
Fix setup-gcloud GH Action and Add setup-python

### DIFF
--- a/.github/actions/setup-gcloud/action.yaml
+++ b/.github/actions/setup-gcloud/action.yaml
@@ -1,0 +1,37 @@
+---
+name: 'Set up Google Cloud'
+description: 'Set up Google Cloud credentials.'
+inputs:
+  PROJECT_ID:
+    description: 'Google project id.'
+    required: true
+  GKE_SA_KEY:
+    description: 'Service account with permissions on `PROJECT_ID`.'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v2
+
+    - name: Authenticate to Google Cloud
+      id: auth
+      uses: google-github-actions/auth@v0
+      with:
+        credentials_json: ${{ inputs.GKE_SA_KEY }}
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v0
+      with:
+        version: "367.0.0"
+        project_id: ${{ inputs.PROJECT_ID }}
+
+    - name: Set up Docker credentials
+      run: |-
+        gcloud auth configure-docker -q
+      shell: bash
+
+    - name: Set up K8s credentials
+      run: |
+        gcloud container clusters get-credentials kube-0 --zone=us-central1-c
+      shell: bash

--- a/.github/actions/setup-python/action.yaml
+++ b/.github/actions/setup-python/action.yaml
@@ -1,0 +1,50 @@
+---
+name: 'Set up Python'
+description: 'Set up Python, PyPi and Poetry.'
+inputs:
+  PYTHON_VERSION:
+    description: 'Python version.'
+    required: false
+    default: "3.7"
+  POETRY_VERSION:
+    description: 'Poetry version.'
+    required: false
+    default: "1.1.12"
+  NEXUS_USERNAME:
+    description: 'Nexus Repository username.'
+    required: true
+  NEXUS_PASSWORD:
+    description: 'Nexus Repository password.'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ inputs.PYTHON_VERSION }}
+
+    - name: Setup pip index
+      run: |
+        mkdir -p ~/.pip
+        cat << EOF > ~/.pip/pip.conf
+        [global]
+        index = https://${{ inputs.NEXUS_USERNAME }}:${{ inputs.NEXUS_PASSWORD }}@nexus.apps.jusbr.com/repository/pypi-all/pypi
+        index-url = https://${{ inputs.NEXUS_USERNAME }}:${{ inputs.NEXUS_PASSWORD }}@nexus.apps.jusbr.com/repository/pypi-all/simple
+        EOF
+      shell: bash
+
+    - name: Install Poetry
+      uses: abatilo/actions-poetry@v2.0.0
+      with:
+        poetry-version: ${{ inputs.POETRY_VERSION }}
+
+    - name: Configure Poetry Access to Nexus
+      run: poetry config http-basic.nexus ${{ inputs.NEXUS_USERNAME }} ${{ inputs.NEXUS_PASSWORD }}
+      shell: bash
+
+    - name: Setup Remote
+      run: poetry config repositories.nexus https://nexus.apps.jusbr.com/repository/pypi-internal/
+      shell: bash

--- a/.github/workflows/reusable-docker-push.yaml
+++ b/.github/workflows/reusable-docker-push.yaml
@@ -33,15 +33,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Google Cloud
-      uses: google-github-actions/setup-gcloud@master
+      uses: ./.github/actions/setup-gcloud
       with:
-        version: "270.0.0"
-        service_account_key: ${{ secrets.GKE_SA_KEY }}
-        project_id: ${{ secrets.PROJECT_ID }}
-
-    - name: Set up Docker credentials
-      run: |-
-        gcloud auth configure-docker -q
+        PROJECT_ID: ${{ secrets.PROJECT_ID }}
+        GKE_SA_KEY: ${{ secrets.GKE_SA_KEY }}
 
     - name: Build docker image
       working-directory: ${{ inputs.WORKDIR }}

--- a/.github/workflows/reusable-pypi-push.yaml
+++ b/.github/workflows/reusable-pypi-push.yaml
@@ -27,22 +27,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-python@v2
+    - name: Set up Python
+      uses: ./.github/actions/setup-python
       with:
-        python-version: ${{ inputs.PYTHON_VERSION }}
-
-    - name: Install Poetry
-      uses: abatilo/actions-poetry@v2.0.0
-      with:
-        poetry-version: ${{ inputs.POETRY_VERSION }}
-
-    - name: Configure Poetry Access to Nexus
-      working-directory: ${{ inputs.WORKDIR }}
-      run: poetry config http-basic.nexus ${{ secrets.NEXUS_USERNAME }} ${{ secrets.NEXUS_PASSWORD }}
-
-    - name: Setup Remote
-      working-directory: ${{ inputs.WORKDIR }}
-      run: poetry config repositories.nexus https://nexus.apps.jusbr.com/repository/pypi-internal/
+        PYTHON_VERSION: ${{ inputs.PYTHON_VERSION }}
+        POETRY_VERSION: ${{ inputs.POETRY_VERSION }}
+        NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+        NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
 
     - name: Build and Publish Lib to Nexus
       working-directory: ${{ inputs.WORKDIR }}

--- a/.github/workflows/reusable-python-checks.yaml
+++ b/.github/workflows/reusable-python-checks.yaml
@@ -30,18 +30,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v2
+      - name: Set up Python
+        uses: ./.github/actions/setup-python
         with:
-          python-version: ${{ inputs.PYTHON_VERSION }}
-
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v2.0.0
-        with:
-          poetry-version: ${{ inputs.POETRY_VERSION }}
-
-      - name: Configure Poetry Access to Nexus
-        working-directory: ${{ inputs.WORKDIR }}
-        run: poetry config http-basic.nexus ${{ secrets.NEXUS_USERNAME }} ${{ secrets.NEXUS_PASSWORD }}
+          PYTHON_VERSION: ${{ inputs.PYTHON_VERSION }}
+          POETRY_VERSION: ${{ inputs.POETRY_VERSION }}
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Install Deps
         working-directory: ${{ inputs.WORKDIR }}
@@ -57,18 +52,14 @@ jobs:
       VERSION: ${{ steps.setvars.outputs.VERSION }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ inputs.PYTHON_VERSION }}
 
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v2.0.0
+      - name: Set up Python
+        uses: ./.github/actions/setup-python
         with:
-          poetry-version: ${{ inputs.POETRY_VERSION }}
-
-      - name: Configure Poetry Access to Nexus
-        working-directory: ${{ inputs.WORKDIR }}
-        run: poetry config http-basic.nexus ${{ secrets.NEXUS_USERNAME }} ${{ secrets.NEXUS_PASSWORD }}
+          PYTHON_VERSION: ${{ inputs.PYTHON_VERSION }}
+          POETRY_VERSION: ${{ inputs.POETRY_VERSION }}
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Install Deps
         working-directory: ${{ inputs.WORKDIR }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+*       @jusbrasil/bigdata


### PR DESCRIPTION
**Why is this PR necessary, what does it do?**
This PR pins `setup-gcloud` to use @v0, removes deprecated `service_account_key`, and also adds `setup-python` action.

**References:**
- Related to https://github.com/jusbrasil/infra/pull/293/commits/4ca7b87ec5313dd3082cb63e31eb7dcbd17b77a2

**Notes:**